### PR TITLE
Ignore cancelled escalations from Zabbix

### DIFF
--- a/bin/pd-zabbix
+++ b/bin/pd-zabbix
@@ -67,6 +67,10 @@ def main():
     # The third argument is the data
     details = _parse_zabbix_body(sys.argv[3])
 
+    # Zabbix will still issue a trigger if the host, trigger, or action gets disabled. Ignore this.
+    if "NOTE" in details and "Escalation cancelled" in details["NOTE"]:
+        return
+
     # Incident key is created by concatenating trigger id and host name.
     # Remember, incident key is used for de-duping and also to match trigger with resolve messages
     incident_key = "%s-%s" % (details["id"], details["hostname"])


### PR DESCRIPTION
When a trigger is issued in Zabbix, the actions will run even if the host, trigger, or action gets disabled. For this case, a note is added like:

NOTE: Escalation cancelled: host "xxx" disabled.

This pull requests looks for this note. If it's found, it will prevent the issuing of the PagerDuty push.
