### PR TITLE
Fix for crash when forgetting a required field when calling pd-nagios

### DIFF
--- a/bin/pd-nagios
+++ b/bin/pd-nagios
@@ -99,7 +99,7 @@ class NagiosEvent:
         if not NagiosEvent.REQUIRED_FIELDS[self._notification_type].issubset(self._details.keys()):
             msg = "Missing fields for type '{0}'.  {1} required".format(
                 self._notification_type,
-                ", ".join(self._required_fields())
+                ", ".join(NagiosEvent.REQUIRED_FIELDS[self._notification_type])
                 )
             raise ValueError(msg)
 


### PR DESCRIPTION
Problem was:
```
root@server:~# /usr/share/pdagent-integrations/bin/pd-nagios -n service -k my_secret -t PROBLEM
Traceback (most recent call last):
  File "/usr/share/pdagent-integrations/bin/pd-nagios", line 188, in <module>
    main()
  File "/usr/share/pdagent-integrations/bin/pd-nagios", line 128, in main
    incident_key = event.enqueue()
  File "/usr/share/pdagent-integrations/bin/pd-nagios", line 58, in enqueue
    self._check_required_fields()
  File "/usr/share/pdagent-integrations/bin/pd-nagios", line 102, in _check_required_fields
    ", ".join(self._required_fields())
AttributeError: NagiosEvent instance has no attribute '_required_fields'
```