### PR TITLE
URGENT: fix for call to queue_event

### DIFF
--- a/bin/pd-nagios
+++ b/bin/pd-nagios
@@ -62,6 +62,8 @@ class NagiosEvent:
             self._service_key,
             self._incident_key(),
             self._event_description(),
+            "",
+            "",
             self._details,
             agent_config.get_agent_id(),
             "pd-nagios"

--- a/bin/pd-zabbix
+++ b/bin/pd-zabbix
@@ -77,7 +77,7 @@ def main():
     agent_config = load_agent_config()
     queue_event(
         agent_config.get_enqueuer(),
-        message_type, service_key, incident_key, description, details,
+        message_type, service_key, incident_key, description, "", "", details,
         agent_config.get_agent_id(), "pd-zabbix",)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Somehow this change made it to the Debian repo recently:
https://github.com/PagerDuty/pdagent/commit/56f0f4064bff3319e6e33bc28b8d88cd72caa0ee#diff-108fba22fdf3ec366bcbd709a4b6a6feL91
This broke the Nagios + Zabbix integration. 
Our PageDuty incident reporting was broken because of this problem, so we missed real incidents.
Please merge my PR and update the `pdagent-integrations` package.