### PR TITLE
Added protection against super-verbose output

### DIFF
--- a/bin/pd-nagios
+++ b/bin/pd-nagios
@@ -70,6 +70,7 @@ class NagiosEvent:
             )
 
     def _event_description(self):
+        from pdagent.constants import MAX_DESCRIPTION_LEN
         if self._notification_type == "service":
             fields = [NagiosEvent.SERVICE_DESCRIPTION,
                 NagiosEvent.SERVICE_STATE,
@@ -81,7 +82,7 @@ class NagiosEvent:
             return None
 
         pairs = ["{0}={1}".format(field, self._details[field]) for field in fields]
-        return "; ".join(pairs)
+        return ("; ".join(pairs))[:MAX_DESCRIPTION_LEN]
 
     def _incident_key(self):
         if self._given_incident_key is None:

--- a/bin/pd-sensu
+++ b/bin/pd-sensu
@@ -58,6 +58,7 @@ class SensuEvent:
             deduplication
         """
         import json
+        from pdagent.constants import MAX_DESCRIPTION_LEN
         self._integration_key = integration_key
         # Parse the body. It should be in the form of a Sensu "check result"
         # https://sensuapp.org/docs/latest/reference/checks.html#check-results 
@@ -89,10 +90,10 @@ class SensuEvent:
             )
         else:
             self._incident_key = details['id']
-        self._description = '%s : %s'%(
+        self._description = ('%s : %s'%(
             self._incident_key,
             details['check']['output']
-        )
+        ))[:MAX_DESCRIPTION_LEN]
 
     def enqueue(self):
         from pdagent.config import load_agent_config

--- a/bin/pd-zabbix
+++ b/bin/pd-zabbix
@@ -57,6 +57,7 @@ def main():
     import sys
     from pdagent.pdagentutil import queue_event
     from pdagent.config import load_agent_config
+    from pdagent.constants import MAX_DESCRIPTION_LEN
 
     # The first argument is the service key
     service_key = sys.argv[1]
@@ -72,7 +73,7 @@ def main():
     incident_key = "%s-%s" % (details["id"], details["hostname"])
 
     # The description that is rendered in PagerDuty and also sent as SMS and phone alert
-    description = "%s : %s for %s" % (details["name"], details["status"], details["hostname"])
+    description = ("%s : %s for %s" % (details["name"], details["status"], details["hostname"]))[:MAX_DESCRIPTION_LEN]
 
     agent_config = load_agent_config()
     queue_event(


### PR DESCRIPTION
Requires commit pdagent/2a2033b (see PR#117)

This truncates the description field to 1024 characters to avoid 400's from the PagerDuty API.