### PR TITLE
Added protection from stray linebreaks

### DIFF
--- a/bin/pd-zabbix
+++ b/bin/pd-zabbix
@@ -42,7 +42,19 @@
 # severity:{TRIGGER.SEVERITY}
 #
 def _parse_zabbix_body(body_str):
-    return dict(line.strip().split(':', 1) for line in body_str.strip().split('\n'))
+    body = {}
+    key, val = (None, None)
+    for line in body_str.strip().split('\n'):
+        keyval = line.strip().split(':', 1)
+        if len(keyval) == 2:
+            key, val = keyval
+            body[key] = val
+        elif key is not None:
+            # Treat as continuation of previous line
+            body[key] += keyval[0]
+        else:
+            body[keyval[0]] = keyval[0]
+    return body
 
 # Parse the Zabbix message subject.
 # The subject MUST be one of the following:


### PR DESCRIPTION
The pd-zabbix script will exhibit the following behavior instead of raising an exception, whenever it encounters a line in the body that does not contain a colon:

* If it's the first line: add the line to the body dictionary with its own value as the key:
* Otherwise: assume that it is a continuation, and append it to the value of the previous line