### PR TITLE
Optional Zabbix client url as "url" property

### DIFF
--- a/bin/pd-zabbix
+++ b/bin/pd-zabbix
@@ -82,10 +82,16 @@ def main():
     # The description that is rendered in PagerDuty and also sent as SMS and phone alert
     description = "%s : %s for %s" % (details["name"], details["status"], details["hostname"])
 
+    # Client URL is an optional property "url" in the Zabbix message
+    client = ""
+    url = details.get('url', '')
+    if url:
+        client = "Zabbix"
+
     agent_config = load_agent_config()
     queue_event(
         agent_config.get_enqueuer(),
-        message_type, service_key, incident_key, description, "", "", details,
+        message_type, service_key, incident_key, description, client, url, details,
         agent_config.get_agent_id(), "pd-zabbix",)
 
 if __name__ == "__main__":


### PR DESCRIPTION
This adds an optional property to the Zabbix body (i.e. it won't error if it's not there but will be used if it is), which allows inserting a link back to Zabbix in the PagerDuty incident.