### PR TITLE
Fixed pagerduty-icinga2.conf to account for missing macros

### DIFF
--- a/conf.d/pagerduty-icinga2.conf
+++ b/conf.d/pagerduty-icinga2.conf
@@ -25,20 +25,24 @@ object NotificationCommand "notify-service-by-pagerduty" {
     "-f" = {
       order = 3
       repeat_key = true
-      value = "$f_args$"
+      value =  {{
+        var f_args = [
+          "SERVICEDESC=" + macro("$service.name$"),
+          "SERVICEDISPLAYNAME=" + macro("$service.display_name$"),
+          "HOSTNAME=" + macro("$host.name$"),
+          "HOSTSTATE=" + macro("$host.state$"),
+          "HOSTDISPLAYNAME=" + macro("$host.display_name$"),
+          "SERVICESTATE=" + macro("$service.state$"),
+          "SERVICEPROBLEMID=" + macro("$service.state_id$"),
+          "SERVICEOUTPUT=" + macro("$service.output$")
+        ]
+        log(f_args)
+        return f_args
+      }}
+      required = true
     }
   }
-  
-  vars.f_args = [
-    "SERVICEDESC=$service.name$",
-    "SERVICEDISPLAYNAME=$service.display_name$",
-    "HOSTNAME=$host.name$",
-    "HOSTSTATE=$host.state$",
-    "HOSTDISPLAYNAME=$host.display_name$",
-    "SERVICESTATE=$service.state$",
-    "SERVICEPROBLEMID=$service.state_id$",
-    "SERVICEOUTPUT=$service.output$" 
-  ]
+
 }
 
 object NotificationCommand "notify-host-by-pagerduty" {


### PR DESCRIPTION
The current version of the `pagerduty-icinga2.conf` does not account for an instance where a macro cannot return a value. If a single macro fails, then the conf will pass an empty array to `pd-nagios`. The new implementation will allow a single macro to fail while still passing values of macros that succeeded to `pd-nagios`.