### PR TITLE
Custom incident_key for zabbix

### DIFF
--- a/bin/pd-zabbix
+++ b/bin/pd-zabbix
@@ -90,7 +90,8 @@ def main():
     # Incident key is created by concatenating trigger id and host name.
     # Remember, incident key is used for de-duping and also to match trigger with resolve messages
     incident_key = "%s-%s" % (details["id"], details["hostname"])
-
+    if "incident_key" in details and details["incident_key"]:
+        incident_key = details["incident_key"]
     # The description that is rendered in PagerDuty and also sent as SMS and phone alert
     description = "%s : %s for %s" % (details["name"], details["status"], details["hostname"])
 


### PR DESCRIPTION
This PR an optional property ``incident_key`` to the zabbix body, which allow to custom incident_key by user. ``incident_key`` is  important to manage de-dup incident s. So it should be selected or decided on ourselves.
e.g.
```
...
incident_key:{HOST.NAME}{TRIGGER.SEVERITY}{HOSTGROUP.ID}
```